### PR TITLE
Added new option to explicitly output config upon setting a top level…

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Options parameters:
                   - NODE_ENV<br/>
                   - or default to "dev"
 
+NOTE: If you want to output the value of your system configuration on loading your config then you can set an option in your environment `config` file with a value of `verboseConfig: true` at the top level. If this is set then the config will be printed to `STDOUT`. 
+
 ## Installation
 
 Install this library via [NPM](https://www.npmjs.org/package/node-nmconfig):

--- a/index.js
+++ b/index.js
@@ -150,7 +150,7 @@ module.exports = function(options) {
   config = combineFiles(files);
   config = combinePackageConfig(config, appName);
   config.rootDir = config.basedir = appRoot;
-  (config.env === 'dev' || config.env === 'test') && console.log('----\nnmConfig, loading configuration object:\n %s\n----\nYour environment config prefix is: ' + reconfigPrefix + '\n----\n', JSON.stringify(config, null, 2));  
+  (config.verboseConfig === true) && console.log('----\nnmConfig, loading configuration object:\n %s\n----\nYour environment config prefix is: ' + reconfigPrefix + '\n----\n', JSON.stringify(config, null, 2));  
 
   return new Reconfig(config, reconfigPrefix, reconfigSeparator);
 }


### PR DESCRIPTION
… config option of `verboseConfig: true`.

This is primarily due to having some quite verbose config being dumped to the output when you might be running tests (and thus starting and restarting quite a lot).